### PR TITLE
Bugfix - Pawn freeze when Allow Medicine < Smart Medicine custom tend, Pharmacist Compatibility

### DIFF
--- a/About/About-Release.xml
+++ b/About/About-Release.xml
@@ -3,10 +3,6 @@
 	<name>Smart Medicine</name>
 	<author>Uuugggg</author>
 	<supportedVersions>
-		<li>1.1</li>
-		<li>1.2</li>
-		<li>1.3</li>
-		<li>1.4</li>
 		<li>1.5</li>
 	</supportedVersions>
 	<packageId>Uuugggg.SmartMedicine</packageId>

--- a/SmartMedicine.sln
+++ b/SmartMedicine.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2009
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.34916.146
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SmartMedicine", "Source\SmartMedicine.csproj", "{D7D21B4A-1DA7-41D8-B202-C58CA8FA62AA}"
 EndProject

--- a/Source/DebugLog.cs
+++ b/Source/DebugLog.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
+﻿
 namespace SmartMedicine
 {
 	static class Log

--- a/Source/FieldTending.cs
+++ b/Source/FieldTending.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Reflection;
 using System.Reflection.Emit;
 using RimWorld;

--- a/Source/FixWhileYoureUp.cs
+++ b/Source/FixWhileYoureUp.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Reflection;
 using Verse;
-using RimWorld;
 using HarmonyLib;
 
 namespace SmartMedicine

--- a/Source/GetPawnMedicalCareCategory.cs
+++ b/Source/GetPawnMedicalCareCategory.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Reflection;
 using Verse;
 using RimWorld;
 using HarmonyLib;

--- a/Source/InventorySurgery.cs
+++ b/Source/InventorySurgery.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using RimWorld;
 using UnityEngine;
 using Verse;

--- a/Source/MedicineGrabbing.cs
+++ b/Source/MedicineGrabbing.cs
@@ -280,7 +280,7 @@ namespace SmartMedicine
 
 	[HarmonyPatch(typeof(HealthAIUtility))]
 	[HarmonyPatch("FindBestMedicine")]
-	[HarmonyBefore(new string[] { "fluffy.rimworld.pharmacist" })]
+	[HarmonyBefore(new string[] { "Fluffy.Pharmacist" })]
 	[StaticConstructorOnStartup]
 	public static class FindBestMedicine
 	{

--- a/Source/MedicineGrabbing.cs
+++ b/Source/MedicineGrabbing.cs
@@ -88,7 +88,7 @@ namespace SmartMedicine
 				//ignore defaultCare if none uses default
 				if (PriorityCareComp.AllPriorityCare(hediffs))
 					defaultCare = maxPriorityCare;
-				
+
 				//Find highest care
 				MedicalCareCategory highestCare = defaultCare > maxPriorityCare ? defaultCare : maxPriorityCare;
 				Log.Message($"maxPriorityCare is {maxPriorityCare}, defaultCare is {defaultCare}, highestCare is {highestCare}");
@@ -164,7 +164,6 @@ namespace SmartMedicine
 				//if (job.count < 1) job.count = 1;
 			}
 			int needCount = Mathf.Min(medicineToDrop.stackCount, job.count);
-
 			Log.Message($"{healer} Starting Tend with {medicineToDrop}:{needCount}");
 
 			job.targetB = DropIt(medicineToDrop, needCount, healer, job);
@@ -184,7 +183,6 @@ namespace SmartMedicine
 		public static Thing DropIt(Thing medicineToUse, int needCount, Pawn healer, Job job)
 		{
 			if (medicineToUse == null || medicineToUse.holdingOwner == null) return null;
-
 			//Well apparently inventory items can be forbidden
 			medicineToUse.SetForbidden(false, false);
 
@@ -387,6 +385,14 @@ namespace SmartMedicine
 			}
 			Log.Message($"Care for {patient} is {defaultCare}, Custom care = {finalCare}");
 
+			//WORKAROUND - 1.4 / 1.5 compatibility
+			if (defaultCare < finalCare)
+			{
+				Log.Message("[2] Pawn default care is lower than hediff care! Elevating default as workaround");
+				patient.playerSettings.medCare = finalCare;
+			}
+
+
 			//Android Droid support;
 			Predicate<Thing> validatorDroid = t => true;
 			bool isDroid = extMechanicalPawn != null && (patient.def.modExtensions?.Any(e => extMechanicalPawn.IsAssignableFrom(e.GetType())) ?? false);
@@ -503,7 +509,7 @@ namespace SmartMedicine
 				Log.Message($"Medicine count = {count}");
 
 				bestMed.DebugLog("Best Med on " + (bestMed.pawn == null ? "ground" : "hand") + ":");
-				
+
 				int usedCount = Mathf.Min(bestMed.thing.stackCount, count);
 				result.Add(new ThingCount(bestMed.thing, usedCount));
 				count -= usedCount;

--- a/Source/SetMedForHediff.cs
+++ b/Source/SetMedForHediff.cs
@@ -195,6 +195,7 @@ namespace SmartMedicine
 
 				int diff = ((int)hediffCare) - ((int)defaultCare);
 				__result += diff*5;//Raise priority for higher meds, lower for lower meds.
+				//__result = (int)hediffCare;
 				return false;
 			}
 			return true;
@@ -262,10 +263,11 @@ namespace SmartMedicine
 
 		public static bool AllowsMedicineForHediff(Pawn deliveree, ThingDef med)
 		{
+			//Should this not be reversed, instead checking for false?
 			if (PriorityCareComp.MaxPriorityCare(deliveree, out MedicalCareCategory heCare))
 			{
-				//This is uses to allow higher medicine above normal limit below.
-				//this is NOT used to stop the job is PriorityCare is lowered
+				//This is used to allow higher medicine above normal limit below.
+				//this is NOT used to stop the job if PriorityCare is lowered
 				if (heCare.AllowsMedicine(med)) return true;
 			}
 

--- a/Source/SetMedForHediff.cs
+++ b/Source/SetMedForHediff.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Reflection;
 using System.Reflection.Emit;
 using RimWorld;

--- a/Source/Settings.cs
+++ b/Source/Settings.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 using Verse;
 using RimWorld;
 using TD.Utilities;

--- a/Source/SmartMedicine.cs
+++ b/Source/SmartMedicine.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Reflection;
-using System.Linq;
-using Verse;
+﻿using Verse;
 using UnityEngine;
 using HarmonyLib;
 using RimWorld;

--- a/Source/SmartMedicine.csproj
+++ b/Source/SmartMedicine.csproj
@@ -37,34 +37,13 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\RimWorldWin64_Data\Managed\Assembly-CSharp.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\..\RimWorldWin64_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-    <Reference Include="UnityEngine.IMGUIModule">
-      <HintPath>..\..\..\RimWorldWin64_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.TextRenderingModule">
-      <HintPath>..\..\..\RimWorldWin64_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="**\*.cs" Exclude="obj\**\*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Lib.Harmony" Version="2.*" ExcludeAssets="runtime"/>
+    <PackageReference Include="Krafs.Rimworld.Ref">
+      <Version>1.5.4104</Version>
+    </PackageReference>
+    <PackageReference Include="Lib.Harmony" Version="2.*" ExcludeAssets="runtime" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Source/StockUp/DontDropStockedDrugs.cs
+++ b/Source/StockUp/DontDropStockedDrugs.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Reflection;
-using System.Reflection.Emit;
-using HarmonyLib;
+﻿using HarmonyLib;
 using RimWorld;
 using Verse;
 

--- a/Source/StockUp/JobDriver_StockUp.cs
+++ b/Source/StockUp/JobDriver_StockUp.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using RimWorld;
+﻿using System.Collections.Generic;
 using Verse;
 using Verse.AI;
 using UnityEngine;

--- a/Source/StockUp/JobGiver_StockUp.cs
+++ b/Source/StockUp/JobGiver_StockUp.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using RimWorld;
 using Verse;
 using Verse.AI;

--- a/Source/StockUp/LowMedicineWarning.cs
+++ b/Source/StockUp/LowMedicineWarning.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using HarmonyLib;
+﻿using HarmonyLib;
 using RimWorld;
 using Verse;
 

--- a/Source/StockUp/StockUpGUI.cs
+++ b/Source/StockUp/StockUpGUI.cs
@@ -3,11 +3,9 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Linq;
-using System.Text;
 using UnityEngine;
 using HarmonyLib;
 using Verse;
-using Verse.AI;
 using RimWorld;
 
 namespace SmartMedicine

--- a/Source/StockUp/StockUpUtility.cs
+++ b/Source/StockUp/StockUpUtility.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Verse;
 using TD.Utilities;
 using HarmonyLib;

--- a/Source/SurgeryUnlimited/SurgeryUnlimited.cs
+++ b/Source/SurgeryUnlimited/SurgeryUnlimited.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Reflection;
 using System.Reflection.Emit;
 using RimWorld;

--- a/Source/SurgeryUnlimited/SurgeryUnlimitedAssignTab.cs
+++ b/Source/SurgeryUnlimited/SurgeryUnlimitedAssignTab.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using RimWorld;
+﻿using RimWorld;
 using Verse;
 using UnityEngine;
 

--- a/Source/Utilities/ExposeableDictionary.cs
+++ b/Source/Utilities/ExposeableDictionary.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Verse;
 
 namespace TD.Utilities

--- a/Source/Utilities/Listing_StandardExtensions.cs
+++ b/Source/Utilities/Listing_StandardExtensions.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using UnityEngine;
 using Verse;
 

--- a/Source/Utilities/PatchCompilerGenerated.cs
+++ b/Source/Utilities/PatchCompilerGenerated.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Reflection;
 using HarmonyLib;
 using Verse;

--- a/Source/Utilities/ReservationUtility.cs
+++ b/Source/Utilities/ReservationUtility.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Verse;
 using Verse.AI;
 


### PR DESCRIPTION
<h3>About:</h3>

**1)**
There is currently a bug where, if the "Allow Medicine" setting for a given pawn is lower than the custom Tend option (Smart Medicine) that you've selected on a given injury, then pawn will stand still whilst a job loop occurs and causes error.

I have added a workaround fix - now, if the selected custom Tend option (Smart Medicine) is higher than the pawns "Allow Medicine" setting, then this setting will change as required before trying to start the job.

This means if you wanted a specific pawn "Allow Medicine" setting to remain lower than prescribed with Smart Medicine after tending is complete, then you would have to change it back manually after treatment.

But no more errors & pawn freezing = WIN

**2)**
The Harmony ID used in the [HarmonyBefore](https://harmony.pardeike.net/api/HarmonyLib.HarmonyBefore.html) call for **Pharmacist** is incorrect.

The result is broken features / incompatibility between these two mods.

Simple change here to use the correct Harmony ID for **Pharmacist**.

**Pharmacist (original):**
https://steamcommunity.com/sharedfiles/filedetails/?id=1365242717

**Pharmacist (my updated 1.5/1.4 fork):**
https://steamcommunity.com/sharedfiles/filedetails/?id=3256204706






