### PR TITLE
Bugfix - pawn freeze when Allow Medicine < Smart Medicine custom tend, Add Hemogen to Stockup

### DIFF
--- a/Source/MedicineGrabbing.cs
+++ b/Source/MedicineGrabbing.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -88,7 +88,7 @@ namespace SmartMedicine
 				//ignore defaultCare if none uses default
 				if (PriorityCareComp.AllPriorityCare(hediffs))
 					defaultCare = maxPriorityCare;
-				
+
 				//Find highest care
 				MedicalCareCategory highestCare = defaultCare > maxPriorityCare ? defaultCare : maxPriorityCare;
 				Log.Message($"maxPriorityCare is {maxPriorityCare}, defaultCare is {defaultCare}, highestCare is {highestCare}");
@@ -280,7 +280,7 @@ namespace SmartMedicine
 
 	[HarmonyPatch(typeof(HealthAIUtility))]
 	[HarmonyPatch("FindBestMedicine")]
-	[HarmonyBefore(new string[] { "fluffy.rimworld.pharmacist" })]
+	[HarmonyBefore(new string[] { "Fluffy.Pharmacist" })]
 	[StaticConstructorOnStartup]
 	public static class FindBestMedicine
 	{
@@ -377,7 +377,7 @@ namespace SmartMedicine
 			var hediffCare = PriorityCareComp.Get();
 			List<Hediff> hediffsToTend = HediffsToTend(patient);
 			Log.Message($"Tending ({hediffsToTend.ToStringSafeEnumerable()})");
-			foreach(Hediff h in hediffsToTend)
+			foreach (Hediff h in hediffsToTend)
 			{
 				MedicalCareCategory toUse = defaultCare;
 				if (hediffCare.TryGetValue(h, out MedicalCareCategory heCare))
@@ -386,6 +386,14 @@ namespace SmartMedicine
 				finalCare = toUse > finalCare ? toUse : finalCare;
 			}
 			Log.Message($"Care for {patient} is {defaultCare}, Custom care = {finalCare}");
+
+			//WORKAROUND for Allowed Care < hediff care bug
+			if (defaultCare < finalCare)
+			{
+				Log.Message("Pawn Allowed Care is lower than hediff care! Elevating Allowed Care as workaround");
+				patient.playerSettings.medCare = finalCare;
+			}
+
 
 			//Android Droid support;
 			Predicate<Thing> validatorDroid = t => true;
@@ -503,7 +511,7 @@ namespace SmartMedicine
 				Log.Message($"Medicine count = {count}");
 
 				bestMed.DebugLog("Best Med on " + (bestMed.pawn == null ? "ground" : "hand") + ":");
-				
+
 				int usedCount = Mathf.Min(bestMed.thing.stackCount, count);
 				result.Add(new ThingCount(bestMed.thing, usedCount));
 				count -= usedCount;

--- a/Source/StockUp/StockUpGUI.cs
+++ b/Source/StockUp/StockUpGUI.cs
@@ -372,7 +372,7 @@ namespace SmartMedicine
 			List<ThingDef> stockable = DefDatabase<ThingDef>.AllDefsListForReading.FindAll(
 				t => t.EverHaulable &&
 				anything ||
-				(t.IsDrug || t.IsMedicine));
+				(t.IsDrug || t.IsMedicine || t == ThingDefOf.HemogenPack));
 			foreach (ThingDef td in stockable)
 			{
 				rowRect.x = x;


### PR DESCRIPTION
<h3>About:</h3>

**1)**

There is currently a bug where, if the "Allow Medicine" setting for a given pawn is lower than the custom Tend option (Smart Medicine) that you've selected on a given injury, then pawn will stand still whilst a job loop occurs and causes error.

I have added a workaround fix - now, if the selected custom Tend option (Smart Medicine) is higher than the pawns "Allow Medicine" setting, then this setting will change as required before trying to start the job.

This means if you wanted a specific pawn "Allow Medicine" setting to remain lower than prescribed with Smart Medicine after tending is complete, then you would have to change it back manually after treatment.

But no more errors & pawn freezing = WIN

It would be better to store the original Allow Medicine value for the pawn and return it after job is complete / avoid this situation entirely and override whatever is blocking the job, but I don't know how to do it or if it's even possible without some heavier lifting (I've tried...) So workaround for now 

**2)**

The Harmony ID used in the [HarmonyBefore](https://harmony.pardeike.net/api/HarmonyLib.HarmonyBefore.html) call for Pharmacist is incorrect.

The result is broken features / incompatibility between these two mods.

Simple change here to use the correct Harmony ID for Pharmacist.

Pharmacist (original):
https://steamcommunity.com/sharedfiles/filedetails/?id=1365242717

Pharmacist (my updated 1.5/1.4 fork):
https://steamcommunity.com/sharedfiles/filedetails/?id=3256204706

**3)**

Added Hemogen to StockUp