### PR TITLE
Bugfix - ReTend compatibility bug

### DIFF
--- a/Source/MedicineGrabbing.cs
+++ b/Source/MedicineGrabbing.cs
@@ -161,8 +161,11 @@ namespace SmartMedicine
 
 				//I don't fuckin understand but maybe a mod conflict makes this 0 and 0 here is bad.
 				//Probably it is sovled with above job.draftedTend though.
-				//if (job.count < 1) job.count = 1;
 			}
+			//ReTend mod, when trying to "ReTend" an injury with medicine in inventory, throws:
+			//Exception filling window for Verse.FloatMenuMap: System.ArgumentException: SplitOff with count <= 0
+			//Workaround:
+			if (job.count < 1) job.count = 1;
 			int needCount = Mathf.Min(medicineToDrop.stackCount, job.count);
 
 			Log.Message($"{healer} Starting Tend with {medicineToDrop}:{needCount}");


### PR DESCRIPTION
**REPORT:**

When using this with the [ReTend ](https://steamcommunity.com/sharedfiles/filedetails/?id=2996971119) mod, if I tell a pawn that already has medicine in their inventory to retend a pawn I get a `"Exception filling window for Verse.FloatMenu: System.ArgumentException: SplitOff with count <= 0 Parameter name: count"` error.

Without smart medicine installed I don't get this error

Log: https://gist.github.com/HugsLibRecordKeeper/b3d6916bcec944998948f04aa3fe69ce

**FIX:**

Added logic to force job.count to 1 if it enters the prefix with < 1


There's already some comments about this in the code, and suggestions that the if `(job.draftedTend)` statement will correct this, however, despite being a drafted choice, ReTend job does not seem to fall into this logic and skips it. Perhaps ReTend does not categorise as a job.draftedTend.


Either way, it is fixed now. Unsure of any wider implications with this change but core functionality looks to be good